### PR TITLE
Update for zig 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.zig-cache
 zig-cache
 zig-out

--- a/README.md
+++ b/README.md
@@ -10,16 +10,19 @@ You can run a demo with `zig build run`. The demo's source is in `src/demo.zig`.
 
 If you want to add the library to your own project...
 
-- Add the `nfd` package to your executable in your `build.zig`
+- Add the `nfd` dependency to your `build.zig.zon`
   ```zig
-  const nfd_build = @import("deps/nfd-zig/build.zig");
-  exe.addPackage(nfd_build.getPackage("nfd"));
+  .{
+    .dependencies = .{
+      .nfd = .{ .path = "libs/nfd-zig" }, // Assuming nfd-zig is available in the local directory. Use .url otherwise.
+    }
+  }
   ```
-- Because `nativefiledialog` is a C library you have to link it to your executable
+- Add the import in your `build.zig`:
   ```zig
-  const nfd_build = @import("deps/nfd-zig/build.zig");
-  const nfd_lib = nfd_build.makeLib(b, mode, target);
-  exe.linkLibrary(nfd_lib);
+  const nfd = b.dependency("nfd", .{});
+  const nfd_mod = nfd.module("nfd");
+  exe.root_module.addImport("nfd", nfd_mod);
   ```
 
 ## Screenshot

--- a/build.zig
+++ b/build.zig
@@ -5,19 +5,19 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const nfd_mod = b.addModule("nfd", .{
-        .root_source_file = .{ .path = "src/lib.zig" },
+        .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
     });
 
     const cflags = [_][]const u8{"-Wall"};
-    nfd_mod.addIncludePath(.{ .path = "nativefiledialog/src/include" });
-    nfd_mod.addCSourceFile(.{ .file = .{ .path = "nativefiledialog/src/nfd_common.c" }, .flags = &cflags });
+    nfd_mod.addIncludePath(b.path("nativefiledialog/src/include"));
+    nfd_mod.addCSourceFile(.{ .file = b.path("nativefiledialog/src/nfd_common.c"), .flags = &cflags });
     switch (target.result.os.tag) {
-        .macos => nfd_mod.addCSourceFile(.{ .file = .{ .path = "nativefiledialog/src/nfd_cocoa.m" }, .flags = &cflags }),
-        .windows => nfd_mod.addCSourceFile(.{ .file = .{ .path = "nativefiledialog/src/nfd_win.cpp" }, .flags = &cflags }),
-        .linux => nfd_mod.addCSourceFile(.{ .file = .{ .path = "nativefiledialog/src/nfd_gtk.c" }, .flags = &cflags }),
+        .macos => nfd_mod.addCSourceFile(.{ .file = b.path("nativefiledialog/src/nfd_cocoa.m"), .flags = &cflags }),
+        .windows => nfd_mod.addCSourceFile(.{ .file = b.path("nativefiledialog/src/nfd_win.cpp"), .flags = &cflags }),
+        .linux => nfd_mod.addCSourceFile(.{ .file = b.path("nativefiledialog/src/nfd_gtk.c"), .flags = &cflags }),
         else => @panic("unsupported OS"),
     }
 
@@ -40,11 +40,11 @@ pub fn build(b: *std.Build) !void {
 
     var demo = b.addExecutable(.{
         .name = "nfd-demo",
-        .root_source_file = .{ .path = "src/demo.zig" },
+        .root_source_file = b.path("src/demo.zig"),
         .target = target,
         .optimize = optimize,
     });
-    demo.addIncludePath(.{ .path = "nativefiledialog/src/include" });
+    demo.addIncludePath(b.path("nativefiledialog/src/include"));
     demo.root_module.addImport("nfd", nfd_mod);
     b.installArtifact(demo);
 


### PR DESCRIPTION
This fixes the `build.zig` script for zig 0.13 (tested with 0.13.0-dev.351+64ef45eb0 to be precise) and updates integration instructions in the Readme to use a `build.zig.zon` file.

`zig-cache` was also changed to `.zig-cache`, so I updated `.gitignore` accordingly.