### PR TITLE
Update for Zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,9 +40,11 @@ pub fn build(b: *std.Build) !void {
 
     var demo = b.addExecutable(.{
         .name = "nfd-demo",
-        .root_source_file = b.path("src/demo.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/demo.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     demo.addIncludePath(b.path("nativefiledialog/src/include"));
     demo.root_module.addImport("nfd", nfd_mod);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = .nfdzig,
+    .fingerprint = 0x1f85e4a3bcf157d7,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.15.1",
+    .paths = .{
+        "nativefiledialog",
+        "src",
+        "LICENSE",
+        "README.md",
+        "build.zig",
+        "build.zig.zon",
+    },
+}

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,3 +1,0 @@
-pub usingnamespace @cImport({
-    @cInclude("nfd.h");
-});

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @cImport({
+    @cInclude("nfd.h");
+});
 const log = std.log.scoped(.nfd);
 
 pub const Error = error{
@@ -34,10 +36,7 @@ pub fn saveFileDialog(filter: ?[:0]const u8, default_path: ?[:0]const u8) Error!
     var out_path: [*c]u8 = null;
 
     // allocates using malloc
-    const result = c.NFD_SaveDialog(
-        if (filter != null) filter.?.ptr else null, 
-        if (default_path != null) default_path.?.ptr else null,
-        &out_path);
+    const result = c.NFD_SaveDialog(if (filter != null) filter.?.ptr else null, if (default_path != null) default_path.?.ptr else null, &out_path);
 
     return switch (result) {
         c.NFD_OKAY => if (out_path == null) null else std.mem.sliceTo(out_path, 0),
@@ -51,9 +50,7 @@ pub fn openFolderDialog(default_path: ?[:0]const u8) Error!?[:0]const u8 {
     var out_path: [*c]u8 = null;
 
     // allocates using malloc
-    const result = c.NFD_PickFolder(
-        if (default_path != null) default_path.?.ptr else null,
-        &out_path);
+    const result = c.NFD_PickFolder(if (default_path != null) default_path.?.ptr else null, &out_path);
 
     return switch (result) {
         c.NFD_OKAY => if (out_path == null) null else std.mem.sliceTo(out_path, 0),


### PR DESCRIPTION
 - Build script: Executable/Library now always take a module
 - usingnamespace was removed in zig 0.15.0 (other changes in this commit are just the result of running `zig fmt`)
 - A build.zig.zon file is necessary to use `zig fetch` to pull this dependency, so I added one.

The Readme could be updated to use zig fetch instead of manually fetching and updating build.zig.zon:

```sh
zig fetch --save git+https://github.com/fabioarnold/nfd-zig.git
```

This will pull the dependency as `nfdzig` instead of `nfd`:
```zig
const nfd = b.dependency("nfdzig", .{});
```
(or change the name in build.zig.zon)