### PR TITLE
Update usage and add screenshots to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ If you want to add the library to your own project:
 zig fetch --save git+https://github.com/fabioarnold/nfd-zig.git
 ```
 
-This will add the `nfdzig` dependency to your `build.zig.zon`. e.g.,
+This will add the `nfd` dependency to your `build.zig.zon`. e.g.,
 
 ```zig
-.nfdzig = .{
+.nfd = .{
     .url = "git+https://github.com/fabioarnold/nfd-zig.git#0ad2a0c092ffba0c98613d619b82100c991f5ad6",
     .hash = "nfdzig-0.1.0-11fxvN6IBgD5rvvfjrw1wPqibMsbUJ-h2ZcGR6FOEvrm",
 },
@@ -30,8 +30,8 @@ This will add the `nfdzig` dependency to your `build.zig.zon`. e.g.,
 - Add the module in your `build.zig`:
 
 ```zig
-const nfdzig = b.dependency("nfdzig", .{ .target = target, .optimize = optimize });
-const nfd_mod = nfdzig.module("nfd");
+const nfd = b.dependency("nfd", .{ .target = target, .optimize = optimize });
+const nfd_mod = nfd.module("nfd");
 exe.root_module.addImport("nfd", nfd_mod);
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can run the demo with `zig build run`. The demo's source is in `src/demo.zig
 
 If you want to add the library to your own project:
 
-- Fetch the `nfdzig` dependency:
+- Fetch the `nfd` dependency:
 
 ```bash
 zig fetch --save git+https://github.com/fabioarnold/nfd-zig.git
@@ -23,7 +23,7 @@ This will add the `nfd` dependency to your `build.zig.zon`. e.g.,
 ```zig
 .nfd = .{
     .url = "git+https://github.com/fabioarnold/nfd-zig.git#0ad2a0c092ffba0c98613d619b82100c991f5ad6",
-    .hash = "nfdzig-0.1.0-11fxvN6IBgD5rvvfjrw1wPqibMsbUJ-h2ZcGR6FOEvrm",
+    .hash = "nfd-0.1.0-11fxvN6IBgD5rvvfjrw1wPqibMsbUJ-h2ZcGR6FOEvrm",
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,54 @@
 # nfd-zig
 
-`nfd-zig` is a Zig binding to the library [nativefiledialog](https://github.com/mlabbe/nativefiledialog) which provides a convenient cross-platform interface to opening file dialogs on Linux, macOS and Windows.
+`nfd-zig` is a Zig binding to the library [nativefiledialog](https://github.com/mlabbe/nativefiledialog)
+which provides a convenient cross-platform interface to opening file dialogs in
+Linux, macOS and Windows.
 
 This library has been tested on Windows 10, macOS 11.1 and Linux.
 
 ## Usage
 
-You can run a demo with `zig build run`. The demo's source is in `src/demo.zig`.
+You can run the demo with `zig build run`. The demo's source is in `src/demo.zig`.
 
-If you want to add the library to your own project...
+If you want to add the library to your own project:
 
-- Add the `nfd` dependency to your `build.zig.zon`
-  ```zig
-  .{
-    .dependencies = .{
-      .nfd = .{ .path = "libs/nfd-zig" }, // Assuming nfd-zig is available in the local directory. Use .url otherwise.
-    }
-  }
-  ```
-- Add the import in your `build.zig`:
-  ```zig
-  const nfd = b.dependency("nfd", .{});
-  const nfd_mod = nfd.module("nfd");
-  exe.root_module.addImport("nfd", nfd_mod);
-  ```
+- Fetch the `nfdzig` dependency:
+
+```bash
+zig fetch --save git+https://github.com/fabioarnold/nfd-zig.git
+```
+
+This will add the `nfdzig` dependency to your `build.zig.zon`. e.g.,
+
+```zig
+.nfdzig = .{
+    .url = "git+https://github.com/fabioarnold/nfd-zig.git#0ad2a0c092ffba0c98613d619b82100c991f5ad6",
+    .hash = "nfdzig-0.1.0-11fxvN6IBgD5rvvfjrw1wPqibMsbUJ-h2ZcGR6FOEvrm",
+},
+```
+
+- Add the module in your `build.zig`:
+
+```zig
+const nfdzig = b.dependency("nfdzig", .{ .target = target, .optimize = optimize });
+const nfd_mod = nfdzig.module("nfd");
+exe.root_module.addImport("nfd", nfd_mod);
+```
+
+- Import and use it your code, e.g., `main.zig`:
+
+```zig
+const nfd = @import("nfd");
+
+pub fn main() !void {
+    const filter = "txt";
+    const default_path: ?[]const u8 = null;
+    const path: ?[]const u8 = try nfd.openFileDialog(filter, default_path);
+}
+```
 
 ## Screenshot
 
 ![Open dialog on Windows 10](https://raw.githubusercontent.com/mlabbe/nativefiledialog/67345b80ebb429ecc2aeda94c478b3bcc5f7888e/screens/open_win.png)
+![Open dialog on Linux with GTK 3](https://raw.githubusercontent.com/mlabbe/nativefiledialog/67345b80ebb429ecc2aeda94c478b3bcc5f7888e/screens/open_gtk3.png)
+![Open dialog on MacOS with Cocoa](https://raw.githubusercontent.com/mlabbe/nativefiledialog/refs/heads/master/screens/open_cocoa.png)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
-    .name = .nfdzig,
-    .fingerprint = 0x1f85e4a3bcf157d7,
+    .name = .nfd,
+    .fingerprint = 0xc47056586ea4cdcb,
     .version = "0.1.0",
     .minimum_zig_version = "0.15.1",
     .paths = .{


### PR DESCRIPTION
The zig ecosystem now relies on `zig fetch --save` to add dependencies so added that in the README and replaced the old one. Also closes #6.