### PR TITLE
Fix build error

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         }),
     });
-    demo.addIncludePath(b.path("nativefiledialog/src/include"));
+    demo.root_module.addIncludePath(b.path("nativefiledialog/src/include"));
     demo.root_module.addImport("nfd", nfd_mod);
     b.installArtifact(demo);
 


### PR DESCRIPTION
Problem:
Using the library as described in the documentation does not work
correctly on 0.16.0-dev.3132+fd2718f82. The demo and consumer projects
fail to build.

```
$zig build run
build.zig:49:9: error: no field or member function named 'addIncludePath' in 'Build.Step.Compile'
demo.addIncludePath(b.path("nativefiledialog/src/include"));
~~~~^~~~~~~~~~~~~~~
/home/roy/.zvm/master/lib/std/Build/Step/Compile.zig:1:1: note: struct declared here
const Compile = @This();
^~~~~
build.zig:49:9: note: method invocation only supports up to one level of implicit pointer dereferencing
build.zig:49:9: note: use '.*' to dereference pointer
referenced by:
runBuild__anon_33897: /home/roy/.zvm/master/lib/std/Build.zig:2265:44
main: /home/roy/.zvm/master/lib/compiler/build_runner.zig:463:29
5 reference(s) hidden; use '-freference-trace=7' to see all references
```

Solution:
change `demo.addIncludePath(...)` to `demo.root_module.addIncludePath(...)`
Fixes the build for my dependant project and the demo
